### PR TITLE
Fix pkg-config paths for staged installs

### DIFF
--- a/openaptx.pc.in
+++ b/openaptx.pc.in
@@ -4,8 +4,8 @@
 
 prefix=@CMAKE_INSTALL_PREFIX@
 exec_prefix=${prefix}
-includedir=${prefix}/@CMAKE_INSTALL_INCLUDEDIR@
-libdir=${prefix}/@CMAKE_INSTALL_LIBDIR@
+includedir=@CMAKE_INSTALL_FULL_INCLUDEDIR@
+libdir=@CMAKE_INSTALL_FULL_LIBDIR@
 
 aptxdecoder=@HAVE_APTX_DECODER@
 aptxencoder=@HAVE_APTX_ENCODER@


### PR DESCRIPTION
## Summary

Use CMake full include and library directory variables so the generated `openaptx.pc` remains correct when the install prefix is an absolute path.

This change was split out of [PR #12](https://github.com/arkq/openaptx/pull/12) at the request of the maintainer. It is independent of the research-only Adaptive changes.

## Verification

- Configured and built with the default backend.
- Verified the generated pkg-config file with an absolute install prefix; both include and library paths resolve to absolute paths.

No proprietary codec files or local machine details are included.