### PR TITLE
Fix backend destroy guards

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -62,6 +62,8 @@ include_directories(${CMAKE_CURRENT_SOURCE_DIR}/include)
 
 include(GNUInstallDirs)
 
+enable_testing()
+
 if(ENABLE_DOC)
 	add_subdirectory(doc)
 endif()

--- a/src/aptx-ffmpeg.c
+++ b/src/aptx-ffmpeg.c
@@ -84,7 +84,7 @@ static int aptx_ffmpeg_init_codec(struct internal_ctx * ctx, const AVCodec * cod
 }
 
 static void aptx_ffmpeg_destroy(struct internal_ctx * ctx) {
-	if (ctx != NULL)
+	if (ctx == NULL)
 		return;
 	av_frame_free(&ctx->av_frame);
 	av_packet_free(&ctx->av_packet);

--- a/src/aptx-freeaptx.c
+++ b/src/aptx-freeaptx.c
@@ -48,7 +48,7 @@ static int aptx_freeaptx_init(struct internal_ctx * ctx, int codec_id, short end
 }
 
 static void aptx_freeaptx_destroy(struct internal_ctx * ctx) {
-	if (ctx != NULL)
+	if (ctx == NULL)
 		return;
 	aptx_finish(ctx->ctx);
 }

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -2,6 +2,11 @@
 # SPDX-FileCopyrightText: 2017-2026 [open]aptx developers
 # SPDX-License-Identifier: MIT
 
+add_executable(aptx-lifecycle-test aptx-lifecycle.c)
+target_compile_features(aptx-lifecycle-test PRIVATE c_std_11)
+target_link_libraries(aptx-lifecycle-test PRIVATE aptx)
+add_test(NAME aptx-lifecycle COMMAND aptx-lifecycle-test)
+
 if(ENABLE_APTX422)
 
 	add_library(qualcomm_libaptx SHARED IMPORTED)

--- a/test/aptx-lifecycle.c
+++ b/test/aptx-lifecycle.c
@@ -1,8 +1,7 @@
 /*
  * [open]aptx - aptx-lifecycle.c tests
- * Copyright (c) 2026 openaptx contributors
- *
- * This project is licensed under the terms of the MIT license.
+ * SPDX-FileCopyrightText: 2026 [open]aptx developers
+ * SPDX-License-Identifier: MIT
  */
 
 #include <assert.h>

--- a/test/aptx-lifecycle.c
+++ b/test/aptx-lifecycle.c
@@ -1,0 +1,31 @@
+/*
+ * [open]aptx - aptx-lifecycle.c tests
+ * Copyright (c) 2026 openaptx contributors
+ *
+ * This project is licensed under the terms of the MIT license.
+ */
+
+#include <assert.h>
+#include <stdlib.h>
+
+#include "openaptx.h"
+
+int main(void) {
+	/* The public API documents NULL as a valid destroy argument. */
+	aptxbtdec_destroy(NULL);
+	aptxhdbtdec_destroy(NULL);
+
+	APTXDEC dec = malloc(SizeofAptxbtdec());
+	assert(dec != NULL);
+	assert(aptxbtdec_init(dec, 0) == 0);
+	aptxbtdec_destroy(dec);
+	free(dec);
+
+	dec = malloc(SizeofAptxhdbtdec());
+	assert(dec != NULL);
+	assert(aptxhdbtdec_init(dec, 0) == 0);
+	aptxhdbtdec_destroy(dec);
+	free(dec);
+
+	return 0;
+}

--- a/test/aptx-lifecycle.c
+++ b/test/aptx-lifecycle.c
@@ -14,17 +14,25 @@ int main(void) {
 	aptxbtdec_destroy(NULL);
 	aptxhdbtdec_destroy(NULL);
 
+	int rc = 0;
+
 	APTXDEC dec = malloc(SizeofAptxbtdec());
-	assert(dec != NULL);
-	assert(aptxbtdec_init(dec, 0) == 0);
-	aptxbtdec_destroy(dec);
+	if (dec == NULL)
+		return 1;
+	if (aptxbtdec_init(dec, 0) == 0)
+		aptxbtdec_destroy(dec);
+	else
+		rc = 1;
 	free(dec);
 
 	dec = malloc(SizeofAptxhdbtdec());
-	assert(dec != NULL);
-	assert(aptxhdbtdec_init(dec, 0) == 0);
-	aptxhdbtdec_destroy(dec);
+	if (dec == NULL)
+		return 1;
+	if (aptxhdbtdec_init(dec, 0) == 0)
+		aptxhdbtdec_destroy(dec);
+	else
+		rc = 1;
 	free(dec);
 
-	return 0;
+	return rc;
 }


### PR DESCRIPTION
## Summary

Fix the inverted NULL checks in the FFmpeg and libfreeaptx cleanup helpers. Previously, a valid context returned before cleanup while a NULL argument could be dereferenced.

Add a lifecycle regression test covering NULL-safe destruction and normal decoder initialization/destruction. Enable CTest so the regression is actually registered on the current `master` base.

This change was split out of [PR #12](https://github.com/arkq/openaptx/pull/12) at the request of the maintainer. It is independent of the research-only Adaptive changes.

## Verification

The default, FFmpeg, and libfreeaptx configurations all build successfully and pass the `aptx-lifecycle` CTest.

No proprietary codec files or local machine details are included.